### PR TITLE
glk: Fix syntax error introduced with dmic split

### DIFF
--- a/glk/sof-glkda7219ma/HiFi.conf
+++ b/glk/sof-glkda7219ma/HiFi.conf
@@ -118,7 +118,7 @@ SectionDevice."Mic" {
 		Channel1 1
 		ChannelPos0 FL
 		ChannelPos1 FR
-
+	}
 }
 
 SectionDevice."Headset" {

--- a/glk/sof-glkrt5682ma/HiFi.conf
+++ b/glk/sof-glkrt5682ma/HiFi.conf
@@ -118,7 +118,7 @@ SectionDevice."Mic" {
 		Channel1 1
 		ChannelPos0 FL
 		ChannelPos1 FR
-
+	}
 }
 
 SectionDevice."Headset" {


### PR DESCRIPTION
I have only verified `glk/sof-glkrt5682ma`, used on bobba360.